### PR TITLE
Hook members hash ids to 3D canary nodes

### DIFF
--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,36 +1,29 @@
 import ThreeCanary from "@kappasigmamu/canary-component"
+import { Vec } from '@polkadot/types'
+import { AccountId32 } from '@polkadot/types/interfaces'
+import { useEffect, useState } from "react"
 import { Col, Row } from 'react-bootstrap'
 import { Link, useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 import { useAccount } from '../account/AccountContext'
 import { PrimaryLgButton } from '../components/base'
 import { fetchAccounts } from '../helpers/fetchAccounts'
+import { useKusama } from '../kusama'
 import KappaSigmaMuTitle from '../static/kappa-sigma-mu-title.svg'
-
-const choose = (choices: Array<string>) => {
-  const index = Math.floor(Math.random() * choices.length)
-  return choices[index]
-}
-
-const nodesDataFactory = (n: number) => {
-  const data = []
-  for (let i=0; i<n; i+=1) {
-    data.push({
-      "id": Math.floor(Math.random()*100),
-      "name": choose(["Arthur C. Clarke", "Douglas Adams", "Isaac Asimov"]),
-      "level": choose(["human", "cyborg"]),
-      "hash": choose(["0x08eded6a76d84e309e3f09705ea2853f", "0xdeadbeefe6a76d84e309e3f09705ea28589"]),
-      // "img": choose(["/assets/t1.jpg", "/assets/t2.jpg"])
-    })
-  }
-  return data
-}
-
-const nodesData = nodesDataFactory(1500)
 
 const LandingPage = () => {
   const navigate = useNavigate()
   const { activeAccount, setActiveAccount, setAccounts } = useAccount()
+  const { api } = useKusama()
+  const [members, setMembers] = useState<Array<string>>([""])
+
+  useEffect(() => {
+    if (api) {      
+      api.query.society.members().then((response: Vec<AccountId32>) => {
+        setMembers(response.map((account) => account.toString()))
+      })
+    }
+  }, [api])
 
   const handlePrimaryButtonClick = () => {
     if (!activeAccount) {
@@ -45,7 +38,11 @@ const LandingPage = () => {
         <div className="position-absolute h-100">
           <ThreeCanary
               objectUrl={`./static/canary.glb`}
-              nodes={nodesData}
+              nodes={
+                members.map((id : string) => ({
+                  "hash": id.toString()
+                }))
+              }
           />
         </div>
         <CentralizedCol xs={6} />


### PR DESCRIPTION
This PR queries society API for members' ids and pass them to 3D canary nodes through a `members` hook.

For now, only hash ids are displayed:

![Screenshot from 2021-11-22 00-28-04](https://user-images.githubusercontent.com/49062/142796932-3ba2aec2-77bb-4c2f-b74e-66ad2ce4bdc7.png)
