### PR TITLE
[UI/UX] Fix canary's z-index in the journey pages

### DIFF
--- a/src/components/Level.tsx
+++ b/src/components/Level.tsx
@@ -13,6 +13,7 @@ const CanaryImg = styled.img`
   position: absolute;
   top: 23%;
   left: 11%;
+  z-index: -1;
 `
 
 const CanaryLevel1 = <CanaryImg src={CanarySvgLevel1} alt="Canary Level 1" />

--- a/src/pages/JourneyPage.tsx
+++ b/src/pages/JourneyPage.tsx
@@ -10,15 +10,15 @@ const JourneyPage = (): JSX.Element => (
     <StyledDiv>
       <Container>
         <Row>
-          <Col sm={3}>
+          <StyledCol sm={3}>
             <Level />
-          </Col>
-          <Col sm={4}>
+          </StyledCol>
+          <StyledCol sm={4}>
             <LevelNotification />
-          </Col>
-          <Col sm={5}>
+          </StyledCol>
+          <StyledCol sm={5}>
             <NextStep />
-          </Col>
+          </StyledCol>
         </Row>
       </Container>
     </StyledDiv>
@@ -31,6 +31,10 @@ const StyledDiv = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
+`
+
+const StyledCol = styled(Col)`
+  z-index: 10;
 `
 
 export { JourneyPage }


### PR DESCRIPTION
Hiiii, this is a PR to fix the canary z-index.

## Before:
![image](https://user-images.githubusercontent.com/16845851/144722646-5c0906f8-4e2d-42f1-aefe-26a0f43a6309.png)

## After:
![image](https://user-images.githubusercontent.com/16845851/144722630-3a086036-18a8-450b-8fea-b1ab43e32e9f.png)
