### PR TITLE
Add bid/vouch info to suspended list

### DIFF
--- a/src/pages/explore/CandidatesPage/components/CandidatesList.tsx
+++ b/src/pages/explore/CandidatesPage/components/CandidatesList.tsx
@@ -2,7 +2,7 @@ import Identicon from '@polkadot/react-identicon'
 import { Col } from 'react-bootstrap'
 import { DataHeaderRow, DataRow } from '../../../../components/base'
 import { FormatBalance } from '../../../../components/FormatBalance'
-import { truncateMiddle } from '../../../../helpers/truncate'
+import { truncate, truncateMiddle } from '../../../../helpers/truncate'
 
 const CandidatesList = ({ candidates }: { candidates: SocietyCandidate[] }): JSX.Element => {
   if (candidates.length === 0) return (
@@ -11,7 +11,7 @@ const CandidatesList = ({ candidates }: { candidates: SocietyCandidate[] }): JSX
   
   return (<>
     <DataHeaderRow>
-      <Col xs={1} className="text-start">#</Col>
+      <Col xs={1} className="text-center">#</Col>
       <Col xs={3} className="text-start">Wallet Hash</Col>
       <Col className="text-start">Bid Kind</Col>
       <Col></Col>
@@ -20,24 +20,24 @@ const CandidatesList = ({ candidates }: { candidates: SocietyCandidate[] }): JSX
     
     {candidates.map((candidate: SocietyCandidate) => (
       <DataRow key={candidate.accountId.toString()}>
-        <Col xs={1} className="text-start">
+        <Col xs={1} className="text-center">
           <Identicon value={candidate.accountId} size={32} theme={'polkadot'} />
         </Col>
         <Col xs={3} className="text-start text-truncate">
           {truncateMiddle(candidate.accountId?.toString())}
         </Col>
-        <Col>
+        <Col xs={1}>
           {candidate.kind.isDeposit ? 'Deposit' : 'Vouch'}
         </Col>
-        <Col className="text-start">
+        <Col xs={4} className="text-start">
           {candidate.kind.isDeposit
             ? <FormatBalance balance={candidate.value} />
-            : (<p>
-                Vouching Member: {candidate.kind.asVouch[0].toHuman()} -
-                Vouching Tip: {candidate.kind.asVouch[1].toHuman()}
-               </p>)}
+            : (<>
+                Member: {truncate(candidate.kind.asVouch[0].toHuman(), 7)} |
+                Tip: {<FormatBalance balance={candidate.kind.asVouch[1]}></FormatBalance>}
+               </>)}
         </Col>
-        <Col>
+        <Col xs={3}>
           Skeptics
         </Col>
       </DataRow>))}

--- a/src/pages/explore/SuspendedPage/components/SuspendedList.tsx
+++ b/src/pages/explore/SuspendedPage/components/SuspendedList.tsx
@@ -1,19 +1,17 @@
 import Identicon from '@polkadot/react-identicon'
 import { AccountId } from '@polkadot/types/interfaces'
-import { arrayFlatten } from '@polkadot/util'
 import { Col, Badge } from 'react-bootstrap'
 import { DataHeaderRow, DataRow } from '../../../../components/base'
-import { truncateMiddle } from '../../../../helpers/truncate'
+import { FormatBalance } from '../../../../components/FormatBalance'
+import { truncate, truncateMiddle } from '../../../../helpers/truncate'
 
 type SuspendedListProps = { 
-  candidates: AccountId[]
+  candidates: SuspendedCandidate[]
   members: AccountId[] 
 }
 
 const SuspendedList = ({ candidates, members }: SuspendedListProps): JSX.Element => {
-  const accountIds = arrayFlatten([members, candidates])
-
-  if (accountIds.length === 0) return (
+  if (candidates.length === 0 && members.length === 0) return (
     <>No suspended members or candidates</>
   )
   
@@ -21,26 +19,49 @@ const SuspendedList = ({ candidates, members }: SuspendedListProps): JSX.Element
     <DataHeaderRow>
       <Col xs={1} className="text-center">#</Col>
       <Col xs={3} className="text-start">Wallet Hash</Col>
-      <Col xs={8} className="text-end"></Col>
+      <Col xs={8} className="text-start">Bid Kind</Col>
     </DataHeaderRow>
-    {accountIds.map((accountId: AccountId) => {
-      const isMember = members.indexOf(accountId) >= 0
-      return (
-        <DataRow key={accountId.toString()}>
-          <Col xs={1} className="text-center">
-            <Identicon value={accountId} size={32} theme="polkadot" />
-          </Col>
-          <Col xs={3} className="text-start text-truncate">
-            {truncateMiddle(accountId.toString())}
-          </Col>
-          <Col xs={8} className="text-end">
-            <Badge pill bg={isMember ? "primary" : "dark"} className="me-2 p-2">
-              {isMember ? <>Member</> : <>Candidate</>}
-            </Badge>
-          </Col>
-        </DataRow>
-      )
-    })}
+    {members.map((accountId: AccountId) => (
+      <DataRow key={accountId.toString()}>
+        <Col xs={1} className="text-center">
+          <Identicon value={accountId} size={32} theme="polkadot" />
+        </Col>
+        <Col xs={3} className="text-start text-truncate">
+          {truncateMiddle(accountId.toString())}
+        </Col>
+        <Col xs={8} className="text-end">
+          <Badge pill bg="primary" className="me-2 p-2">
+            Member
+          </Badge>
+        </Col>
+      </DataRow>
+    ))}
+    {candidates.map((candidate: SuspendedCandidate) => (
+      <DataRow key={candidate.accountId.toString()}>
+      <Col xs={1} className="text-center">
+        <Identicon value={candidate.accountId} size={32} theme="polkadot" />
+      </Col>
+      <Col xs={3} className="text-start text-truncate">
+        {truncateMiddle(candidate.accountId.toString())}
+      </Col>
+      <Col xs={1}>
+        {candidate.bid.isDeposit ? <>Deposit</> : <>Vouch</>}
+      </Col>
+      <Col xs={4}>
+        {candidate.bid.isDeposit 
+          ? <FormatBalance balance={candidate.balance} /> 
+          : (<>
+              Member: {truncate(candidate.bid.asVouch[0].toHuman(), 7)} |
+              Tip: {<FormatBalance balance={candidate.bid.asVouch[1]}></FormatBalance>}
+             </>)}
+      </Col>
+      <Col xs={3} className="text-end">
+        <Badge pill bg="dark" className="me-2 p-2">
+          Candidate
+        </Badge>
+      </Col>
+    </DataRow>
+    ))}
   </>)
 }
 

--- a/src/pages/explore/SuspendedPage/helpers/data-extraction.tsx
+++ b/src/pages/explore/SuspendedPage/helpers/data-extraction.tsx
@@ -1,0 +1,24 @@
+import { Option, StorageKey } from '@polkadot/types'
+import { AccountId, BalanceOf } from '@polkadot/types/interfaces'
+import { PalletSocietyBidKind } from '@polkadot/types/lookup'
+import { ITuple } from '@polkadot/types/types'
+
+type suspendedCandidateEntry = [
+  StorageKey<[AccountId]>, 
+  Option<ITuple<[BalanceOf, PalletSocietyBidKind]>>
+]
+
+export const extractAccountIds = (keys: StorageKey<[AccountId]>[]): AccountId[] => {
+  return keys.map(({ args: [accountId] }) => accountId).filter((a) => !!a)
+}
+
+export const extractCandidates = (entries: suspendedCandidateEntry[]): SuspendedCandidate[] => {
+  return entries
+    .filter(([{ args: [accountId] }, opt]) => opt.isSome && accountId)
+    .map(([{ args: [accountId] }, opt]) => {
+      const [balance, bid] = opt.unwrap()
+
+      return { accountId, balance, bid }
+    })
+    .sort((a, b) => a.balance.cmp(b.balance))
+}

--- a/src/pages/explore/SuspendedPage/index.tsx
+++ b/src/pages/explore/SuspendedPage/index.tsx
@@ -1,16 +1,12 @@
 import { ApiPromise } from '@polkadot/api'
-import { StorageKey } from '@polkadot/types'
 import { AccountId } from '@polkadot/types/interfaces'
 import { useEffect, useState } from 'react'
 import { Spinner } from 'react-bootstrap'
 import { SuspendedList } from './components/SuspendedList'
+import { extractAccountIds, extractCandidates } from './helpers/data-extraction'
 
 type SuspendedPageProps = {
   api: ApiPromise | null
-}
-
-const extractAccountIds = (keys: StorageKey<[AccountId]>[]): AccountId[] => {
-  return keys.map(({ args: [accountId] }) => accountId).filter((a) => !!a)
 }
 
 const SuspendedPage = ({ api }: SuspendedPageProps): JSX.Element => {
@@ -20,7 +16,7 @@ const SuspendedPage = ({ api }: SuspendedPageProps): JSX.Element => {
     <Spinner animation="border" variant="primary" />
   )
 
-  const [candidates, setCandidates] = useState<AccountId[]>([])
+  const [candidates, setCandidates] = useState<SuspendedCandidate[]>([])
   const [members, setMembers] = useState<AccountId[]>([])
 
   useEffect(() => {
@@ -28,8 +24,8 @@ const SuspendedPage = ({ api }: SuspendedPageProps): JSX.Element => {
       .then(extractAccountIds)
       .then(setMembers)
     
-    api.query.society.suspendedCandidates.keys()
-      .then(extractAccountIds)
+    api.query.society.suspendedCandidates.entries()
+      .then(extractCandidates)
       .then(setCandidates)
   }, [])
 

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -23,6 +23,12 @@ declare interface SocietyCandidate {
   skeptics: string[]
 }
 
+declare interface SuspendedCandidate {
+  accountId: AccountId
+  balance: BalanceOf
+  bid: PalletSocietyBidKind
+}
+
 declare interface SocietyMember {
   accountId: AccountId
   hasPayouts: boolean


### PR DESCRIPTION
As the title says, this PR adds bid/vouch info to the suspended list. It also includes some improvements to the candidates page so it looks more user-friendly and standardized with the other pages/elements. 

![image](https://user-images.githubusercontent.com/1481940/170117369-6b3f4618-e14c-400c-a397-20dab759e8ff.png)
