### PR TITLE
Handle promise error during bid extrinsic 

### DIFF
--- a/src/pages/explore/BiddersPage/BidVouch.tsx
+++ b/src/pages/explore/BiddersPage/BidVouch.tsx
@@ -20,18 +20,17 @@ const BidVouch = ({ handleResult, activeAccount } : BidVouchProps) => {
       const injector = await web3FromAddress(activeAccount.address)
 
       bid?.signAndSend(activeAccount.address, { signer: injector.signer }, ({ status }) => {
-        const _status = status.type.toString()
-        let text
-
-        if (_status === 'Finalized') {
+        if (status.isFinalized) {
+          handleResult({ message: 'Bid submitted successfully. You are now a Bidder' , success: true })
           setLoading(false)
-          text = 'Bid submitted successfully. You are now a Bidder'
         } else {
+          handleResult({ message: `Bid request sent. Waiting for response...`, success: true })
           setLoading(true)
-          text = `Bid request sent. Waiting for response...`
         }
 
-        handleResult(text)
+      }).catch((err) => {
+        setLoading(false)
+        handleResult({ message: err.message, success: false })
       })
     }
 

--- a/src/pages/explore/BiddersPage/index.tsx
+++ b/src/pages/explore/BiddersPage/index.tsx
@@ -8,11 +8,16 @@ import { useKusama } from '../../../kusama'
 import { BiddersList } from './BiddersList'
 import { BidVouch } from './BidVouch'
 
+interface BidResult {
+  message: string;
+  success: boolean;
+}
+
 const BiddersPage = (): JSX.Element => {
   const { api } = useKusama()
   const { activeAccount, accounts } = useAccount()
   const [bids, setBids] = useState<Vec<PalletSocietyBid> | []>([])
-  const [result, setResult] = useState(null)
+  const [result, setResult] = useState<BidResult>()
   const [showAlert, setShowAlert] = useState(true)
 
   const loading = !api?.query?.society
@@ -25,7 +30,7 @@ const BiddersPage = (): JSX.Element => {
     }
   }, [api?.query?.society])
 
-  const handleResult = useCallback((result) => {
+  const handleResult = useCallback(result => {
     setResult(result)
     setShowAlert(true)
   }, [])
@@ -36,7 +41,12 @@ const BiddersPage = (): JSX.Element => {
 
   return (
     <>
-      {(result && showAlert) && <StyledAlert onClose={() => setShowAlert(false)} dismissible>{result}</StyledAlert>}
+      {(result && showAlert) &&
+        <StyledAlert
+          success={result.success}
+          onClose={() => setShowAlert(false)}
+          dismissible>{result.message}
+        </StyledAlert>}
       <Row>
         <Col>
           <BidVouch accounts={accounts} activeAccount={activeAccount} handleResult={handleResult} />
@@ -49,13 +59,19 @@ const BiddersPage = (): JSX.Element => {
   )
 }
 
-const StyledAlert = styled(Alert)`
+interface StyledAlertProps {
+  success: boolean;
+}
+
+const StyledAlert = styled(Alert)<StyledAlertProps>`
   background-color: #1A1D20;
-  border-color: #A7FB8F;
-  color: #A7FB8F;
+  border-color: ${props => props.success ? '#A7FB8F' : '#ED6464'};
+  color: ${props => props.success ? '#A7FB8F' : '#ED6464'};
 
   .btn-close {
-    filter: invert(88%) sepia(27%) saturate(621%) hue-rotate(50deg) brightness(97%) contrast(104%);
+    filter: ${props => props.success
+      ? 'invert(88%) sepia(27%) saturate(621%) hue-rotate(50deg) brightness(97%) contrast(104%);'
+      : 'invert(58%) sepia(6%) saturate(6386%) hue-rotate(315deg) brightness(94%) contrast(96%);'}
   }
 `
 


### PR DESCRIPTION
Bonjour

Previously we were not catching some errors that happened during the bid phase, those raised from the failure of the promise. In practice, this meant that the bid promise would fail and the user was left with a screen unchanged, since the error treatment wasn't being done.

Below is an example of an error that happens via a promise fail (low balance):

![simplescreenrecorder-2022-06-05_22 04 20](https://user-images.githubusercontent.com/21130697/172078715-c276df56-ad7f-406a-8282-b0b2af21a15c.gif)


**Important:** we still need run some pre checks during the bid, like if the member is already suspended. However, in this specific case, all the society members would have to be acquired via another RPC call and a filter applied, and since this call is already present in many places in the application, maybe a memoization could be done and accessed via a hook.