### PR TITLE
Fix loading on all pages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,6 +43,7 @@ module.exports = {
     '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/ban-ts-ignore': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-non-null-assertion': 'off',
     'import/newline-after-import': ['warn'],
     'import/no-default-export': ['warn'],
     'import/order': [

--- a/src/account/AccountContext.tsx
+++ b/src/account/AccountContext.tsx
@@ -8,7 +8,6 @@ import { useKusama } from '../kusama'
 
 const activeAccount = localStorage.getItem('activeAccount')
 const isValid = isValidAccount(activeAccount)
-// eslint-disable-next-line  @typescript-eslint/no-non-null-assertion
 let storedActiveAccount = isValid ? JSON.parse(activeAccount!) : null
 storedActiveAccount = storedActiveAccount ? (storedActiveAccount as accountType) : { name: '', address: '' }
 

--- a/src/pages/explore/BiddersPage/BiddersList.tsx
+++ b/src/pages/explore/BiddersPage/BiddersList.tsx
@@ -10,8 +10,9 @@ import { humanizeBidKind } from '../../../helpers/humanize'
 import { truncateMiddle } from '../../../helpers/truncate'
 import { useKusama } from '../../../kusama'
 
-type Props = { bids: Vec<PalletSocietyBid> | [], activeAccount: accountType; handleResult: any }
+type Props = { bids: Vec<PalletSocietyBid>, activeAccount: accountType; handleResult: any }
 
+// TODO: move this to a `components` directory to follow the convention of other pages 
 const BiddersList = ({ bids, activeAccount, handleResult } : Props) : JSX.Element => {
   const { api, apiState } = useKusama()
   const [loading, setLoading] = useState(false)

--- a/src/pages/explore/BiddersPage/BiddersList.tsx
+++ b/src/pages/explore/BiddersPage/BiddersList.tsx
@@ -44,6 +44,8 @@ const BiddersList = ({ bids, activeAccount, handleResult } : Props) : JSX.Elemen
     apiReady && unbid()
   }
 
+  if (bids.length === 0) return <>No bids</>
+
   return (
     <>
       <DataHeaderRow>

--- a/src/pages/explore/BiddersPage/index.tsx
+++ b/src/pages/explore/BiddersPage/index.tsx
@@ -1,42 +1,41 @@
 import type { Vec } from '@polkadot/types'
 import type { PalletSocietyBid } from '@polkadot/types/lookup'
 import { useEffect, useState, useCallback } from 'react'
-import { Spinner, Row, Col, Alert } from 'react-bootstrap'
+import { Row, Col, Alert } from 'react-bootstrap'
 import styled from 'styled-components'
 import { useAccount } from '../../../account/AccountContext'
 import { useKusama } from '../../../kusama'
+import { LoadingSpinner } from '../components/LoadingSpinner'
 import { BiddersList } from './BiddersList'
 import { BidVouch } from './BidVouch'
 
 interface BidResult {
-  message: string;
-  success: boolean;
+  message: string
+  success: boolean
 }
 
 const BiddersPage = (): JSX.Element => {
   const { api } = useKusama()
   const { activeAccount, accounts } = useAccount()
-  const [bids, setBids] = useState<Vec<PalletSocietyBid> | []>([])
+  const [bids, setBids] = useState<Vec<PalletSocietyBid> | null>(null)
   const [result, setResult] = useState<BidResult>()
   const [showAlert, setShowAlert] = useState(true)
 
-  const loading = !api?.query?.society
+  const society = api?.query?.society
 
   useEffect(() => {
-    if (!loading) {
-      api.query.society.bids((response: Vec<PalletSocietyBid>) => {
-        setBids(response)
-      })
-    }
-  }, [api?.query?.society])
+    society?.bids((response: Vec<PalletSocietyBid>) => {
+      setBids(response)
+    })
+  }, [society])
 
   const handleResult = useCallback(result => {
     setResult(result)
     setShowAlert(true)
   }, [])
 
-  const content = loading
-    ? <Spinner animation="border" variant="primary" />
+  const content = bids === null
+    ? <LoadingSpinner />
     : <BiddersList bids={bids} activeAccount={activeAccount} handleResult={handleResult} />
 
   return (
@@ -60,7 +59,7 @@ const BiddersPage = (): JSX.Element => {
 }
 
 interface StyledAlertProps {
-  success: boolean;
+  success: boolean
 }
 
 const StyledAlert = styled(Alert)<StyledAlertProps>`

--- a/src/pages/explore/CandidatesPage/index.tsx
+++ b/src/pages/explore/CandidatesPage/index.tsx
@@ -1,7 +1,7 @@
 import { ApiPromise } from '@polkadot/api'
 import { DeriveSocietyCandidate } from '@polkadot/api-derive/types'
 import { useEffect, useState } from 'react'
-import { Spinner } from 'react-bootstrap'
+import { LoadingSpinner } from '../components/LoadingSpinner'
 import { buildSocietyCandidatesArray } from '../helpers'
 import { CandidatesList } from './components/CandidatesList'
 
@@ -10,22 +10,22 @@ type CandidatesPageProps = {
 }
 
 const CandidatesPage = ({ api }: CandidatesPageProps): JSX.Element => {
-  const loading = !api?.query?.society
-  const [candidates, setCandidates] = useState<SocietyCandidate[]>([])
-
-  if (loading) return (
-    <Spinner animation="border" variant="primary" />
-  )
+  const society = api?.derive?.society
+  const [candidates, setCandidates] = useState<SocietyCandidate[] | null>(null)
 
   useEffect(() => {
-    api.derive.society.candidates((responseCandidates: DeriveSocietyCandidate[]) => {
-      buildSocietyCandidatesArray(api, responseCandidates)
+    society?.candidates((responseCandidates: DeriveSocietyCandidate[]) => {
+      buildSocietyCandidatesArray(api!, responseCandidates)
         .then(setCandidates)
         .catch(console.error)
     })
-  }, [])
+  }, [society])
 
-  return (<CandidatesList candidates={candidates}/>)
+  return (
+    candidates === null 
+    ? <LoadingSpinner />
+    : <CandidatesList candidates={candidates}/>
+  )
 }
 
 export { CandidatesPage }

--- a/src/pages/explore/MembersPage/components/MembersList.tsx
+++ b/src/pages/explore/MembersPage/components/MembersList.tsx
@@ -12,6 +12,10 @@ const StyledDataRow = styled(DataRow)`
 `
 
 const MembersList = ({ members, api }: { members: SocietyMember[], api: ApiPromise }): JSX.Element => {
+  // Likely impossible to happen but if it does, better to show a 
+  // clear message than an empty list which may look like a loading state
+  if (members.length === 0) return <>No members</>
+
   return (<>
     <DataHeaderRow>
       <Col xs={1} className="text-center">#</Col>

--- a/src/pages/explore/MembersPage/index.tsx
+++ b/src/pages/explore/MembersPage/index.tsx
@@ -1,8 +1,8 @@
 import { ApiPromise } from '@polkadot/api'
 import { DeriveSociety, DeriveSocietyMember } from '@polkadot/api-derive/types'
 import { useEffect, useState } from 'react'
-import { Spinner } from 'react-bootstrap'
 import { useConsts } from '../../../hooks/useConsts'
+import { LoadingSpinner } from '../components/LoadingSpinner'
 import { buildSocietyMembersArray } from '../helpers'
 import { MembersList } from './components/MembersList'
 
@@ -11,24 +11,22 @@ type MembersPageProps = {
 }
 
 const MembersPage = ({ api }: MembersPageProps): JSX.Element => {
-  const loading = !api?.derive.society
-  const [members, setMembers] = useState<SocietyMember[]>([])
+  const society = api?.derive.society
+  const [members, setMembers] = useState<SocietyMember[] | null>(null)
   const { maxStrikes } = useConsts()
 
-  if (loading) return (
-    <Spinner animation="border" variant="primary" />
-  )
-
   useEffect(() => {
-    api.derive.society.info().then((info: DeriveSociety) => {
-      api.derive.society.members().then((responseMembers: DeriveSocietyMember[]) => {
+    society?.info().then((info: DeriveSociety) => {
+      society?.members().then((responseMembers: DeriveSocietyMember[]) => {
         setMembers(buildSocietyMembersArray(responseMembers, info, maxStrikes))
       })
     })
-  }, [])
+  }, [society])
 
   return (
-    <MembersList api={api} members={members} />
+    members === null 
+      ? <LoadingSpinner />
+      : <MembersList api={api!} members={members} />
   )
 }
 

--- a/src/pages/explore/SuspendedPage/index.tsx
+++ b/src/pages/explore/SuspendedPage/index.tsx
@@ -1,7 +1,7 @@
 import { ApiPromise } from '@polkadot/api'
 import { AccountId } from '@polkadot/types/interfaces'
 import { useEffect, useState } from 'react'
-import { Spinner } from 'react-bootstrap'
+import { LoadingSpinner } from '../components/LoadingSpinner'
 import { SuspendedList } from './components/SuspendedList'
 import { extractAccountIds, extractCandidates } from './helpers/data-extraction'
 
@@ -10,26 +10,26 @@ type SuspendedPageProps = {
 }
 
 const SuspendedPage = ({ api }: SuspendedPageProps): JSX.Element => {
-  const loading = !api?.query?.society
+  const society = api?.query?.society
 
-  if (loading) return (
-    <Spinner animation="border" variant="primary" />
-  )
-
-  const [candidates, setCandidates] = useState<SuspendedCandidate[]>([])
-  const [members, setMembers] = useState<AccountId[]>([])
+  const [candidates, setCandidates] = useState<SuspendedCandidate[] | null>(null)
+  const [members, setMembers] = useState<AccountId[] | null>(null)
 
   useEffect(() => {
-    api.query.society.suspendedMembers.keys()
+    society?.suspendedMembers.keys()
       .then(extractAccountIds)
       .then(setMembers)
     
-    api.query.society.suspendedCandidates.entries()
+    society?.suspendedCandidates.entries()
       .then(extractCandidates)
       .then(setCandidates)
-  }, [])
+  }, [society])
 
-  return (<SuspendedList members={members} candidates={candidates} />)
+  return (
+    candidates === null || members === null
+    ? <LoadingSpinner />
+    : <SuspendedList members={members!} candidates={candidates!} />
+  )
 }
 
 export { SuspendedPage }

--- a/src/pages/explore/components/LoadingSpinner.tsx
+++ b/src/pages/explore/components/LoadingSpinner.tsx
@@ -1,0 +1,14 @@
+import { Spinner } from "react-bootstrap"
+
+type LoadingSpinnerProps = {
+  center?: boolean
+}
+
+export function LoadingSpinner({ center = true }: LoadingSpinnerProps): JSX.Element {
+  return (
+    <Spinner 
+      animation="border" 
+      variant="primary" 
+      className={center ? "mx-auto d-block" : ""} />
+  )
+}


### PR DESCRIPTION
Loading wasn't showing for any page because the loading state was defined based on the api object presence, not taking into account that entries (members, bids, etc) still need to be loaded. This PR changes the way we handle the states so that `null` state represents not loaded while `[]` state represents loaded but empty.

It also refactors some parts of the code to standardize everything.

https://user-images.githubusercontent.com/1481940/173901075-f5f09be3-3668-42a1-8462-e9a0ea2b2bea.mp4


