### PR TITLE
Fix vertical scrolling

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -15,7 +15,8 @@ const Navbar = ({
     <Container>
       <Nav>{showBrandIcon ? <NavbarBrand /> : <BrandPlaceholder />}</Nav>
       <Nav className="align-items-center align-self-center">
-        {showExploreButton && <Nav.Link to="/explore" as={Link}>Explore</Nav.Link>}
+        {showExploreButton && 
+          <Nav.Link to="/explore" as={Link} onClick={(e) => e.currentTarget.blur()}>Explore</Nav.Link>}
         &nbsp;
         {showSocialIcons && <SocialIcons />}
         &nbsp;

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -1,5 +1,5 @@
-import { Suspense } from 'react'
-import { BrowserRouter, Outlet, Route, Routes } from 'react-router-dom'
+import { Suspense, useLayoutEffect } from 'react'
+import { BrowserRouter, Outlet, Route, Routes, useLocation } from 'react-router-dom'
 import { ThemeProvider } from 'styled-components'
 import { AccountContextProvider } from '../account/AccountContext'
 import { Navbar } from '../components/Navbar'
@@ -12,8 +12,15 @@ import { JourneyPage } from './JourneyPage'
 import { LandingPage } from './LandingPage'
 import { WelcomePage } from './WelcomePage'
 
-const AppNavigation = () => (
-  <>
+const AppNavigation = () => {
+  const location = useLocation()
+
+  useLayoutEffect(() => {
+    const isLandingPage = location.pathname === "/" || location.pathname === ""
+    document.body.style.overflow = isLandingPage ? "hidden" : "auto"
+  }, [location])
+
+  return (<>
     <Navbar
       showAccount
       showExploreButton
@@ -21,8 +28,8 @@ const AppNavigation = () => (
       showSocialIcons
     />
     <Outlet />
-  </>
-)
+  </>)
+}
 
 const AppRouter = () => {
   return (

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -88,8 +88,6 @@ const LandingPage = () => {
     navigate('/journey')
   }
 
-  document.body.style.overflow = "hidden"
-
   return (
     <>
       <MemberOffcanvas


### PR DESCRIPTION
Overflow was being set and kept as "hidden" every time the landing page was loaded. Solution was to find common code executed in every page load (in this case `AppNavigation`) and add an effect listener, making it react (:drum:) to page changes.