### PR TITLE
Handle error for number overflow in BN

### DIFF
--- a/src/pages/explore/BiddersPage/BidVouch.tsx
+++ b/src/pages/explore/BiddersPage/BidVouch.tsx
@@ -3,7 +3,7 @@ import BN from 'bn.js'
 import { useState, useEffect } from 'react'
 import { Spinner, Tab, Nav, Form, Button, InputGroup, FormControl } from 'react-bootstrap'
 import styled from 'styled-components'
-import { bid, vouch } from './helper'
+import { bid, vouch, BNtoNumber } from './helper'
 import { CurrentRound } from '../../../components/rotation-bar/CurrentRound'
 
 type BidVouchProps = { api: ApiPromise; handleResult: any; activeAccount: accountType }
@@ -24,14 +24,14 @@ const BidVouch = ({ api, handleResult, activeAccount }: BidVouchProps) => {
   }
 
   useEffect(() => {
-    if (bidAmount.toNumber() >= 0) {
+    if (BNtoNumber(bidAmount) >= 0) {
       const tx = api.tx.society.bid(bidAmount)
       bid(tx, activeAccount, onStatusChange)
     }
   }, [bidAmount, handleResult])
 
   useEffect(() => {
-    if (vouchAddress && vouchTip.toNumber() >= 0 && vouchValue.toNumber() >= 0) {
+    if (vouchAddress && BNtoNumber(vouchTip) >= 0 && BNtoNumber(vouchValue) >= 0) {
       const tx = api.tx.society.vouch(vouchAddress, vouchValue, vouchTip)
       vouch(tx, activeAccount, onStatusChange)
     }

--- a/src/pages/explore/BiddersPage/helper.ts
+++ b/src/pages/explore/BiddersPage/helper.ts
@@ -1,5 +1,6 @@
 import { SubmittableExtrinsic } from '@polkadot/api/types'
 import { doTx } from '../../../helpers/extrinsitcs'
+import BN from 'bn.js'
 
 export const unbid = async (
   tx: SubmittableExtrinsic<'promise', any>,
@@ -43,4 +44,12 @@ export const vouch = async (
   const waitingText = 'Vouch request sent. Waiting for response...'
 
   await doTx(tx, finalizedText, waitingText, activeAccount, onStatusChange)
+}
+
+export const BNtoNumber = (bn : BN) => {
+  try {
+    return bn.toNumber()
+  } catch (error) {
+    return -1
+  }
 }

--- a/src/pages/explore/BiddersPage/helper.ts
+++ b/src/pages/explore/BiddersPage/helper.ts
@@ -1,6 +1,6 @@
 import { SubmittableExtrinsic } from '@polkadot/api/types'
-import { doTx } from '../../../helpers/extrinsitcs'
 import BN from 'bn.js'
+import { doTx } from '../../../helpers/extrinsitcs'
 
 export const unbid = async (
   tx: SubmittableExtrinsic<'promise', any>,


### PR DESCRIPTION
Hey,

This PR fixes the error below by adding a try/catch clause. If there is an error, a -1 is returned from the BN conversion to bignumber

```
Uncaught Error: Number can only safely store up to 53 bits
    assert bn.js:5
    toNumber bn.js:492
    BidVouch BidVouch.tsx:27
    React 15
    handleBidSubmit BidVouch.tsx:42
    React 15
```

