### PR TITLE
Show transaction messages as toasts

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-dev-utils": "^12.0.1",
     "react-device-detect": "^2.2.3",
     "react-dom": "^18.2.0",
+    "react-hot-toast": "^2.4.1",
     "react-icons": "^4.12.0",
     "react-is": "^18.2.0",
     "react-refresh": "^0.8.3",

--- a/src/components/LoadingContainer.tsx
+++ b/src/components/LoadingContainer.tsx
@@ -20,13 +20,13 @@ const LoadingContainer = ({ state }: any) => {
 
 const StyledLoadingContainer = styled.div`
   position: absolute;
-  z-index: 2;
+  z-index: 2147483647;
   width: 300px;
   top: calc(50% - 70px);
   left: calc(50% - 150px);
   padding: 10px;
   padding-bottom: 15px;
-  background-color: rgba(0, 0, 0, 0.75);
+  background-color: rgba(0, 0, 0, 0.8);
   border-radius: 10px;
 `
 

--- a/src/components/NextStep.tsx
+++ b/src/components/NextStep.tsx
@@ -153,7 +153,7 @@ const NextStep = () => {
 
   return (
     <>
-      <Toaster position="top-right" reverseOrder={true} />
+      <Toaster />
       <StyledP>{level !== 'cyborg' && 'Next Step'}</StyledP>
       {level === 'candidate' && isClaimPeriod ? (
         <ClaimMembershipStep api={api!} showMessage={showMessage} handleUpdate={handleUpdate} />

--- a/src/components/NextStep.tsx
+++ b/src/components/NextStep.tsx
@@ -83,14 +83,14 @@ const ClaimMembershipStep = ({
   handleUpdate: () => void
 }) => (
   <>
-    <h5>It's claim period!</h5>
+    <h5>It's claim time!</h5>
     <p>If you were approved, go ahead and claim your membership:</p>
     &nbsp;&nbsp;
     <ClaimMembershipButton
       api={api!}
       showMessage={showMessage}
       successText="Claim request sent."
-      waitingText="Claim request sent. Waiting for response..."
+      waitingText="Request sent. Waiting for response..."
       handleUpdate={handleUpdate}
     ></ClaimMembershipButton>
   </>
@@ -180,9 +180,9 @@ function ClaimMembershipButton({
   const { activeAccount } = useAccount()
 
   const onStatusChange: StatusChangeHandler = ({ loading, message, status }) => {
-    loading && setLoading(loading)
+    setLoading(loading!)
     showMessage({ status, message })
-    if (!loading && status === 'success') handleUpdate()
+    if (!loading && message !== 'Transaction submitted.' && status === 'success') handleUpdate()
   }
 
   const handleClaim = async () => {

--- a/src/components/NextStep.tsx
+++ b/src/components/NextStep.tsx
@@ -12,6 +12,7 @@ import { useAccount } from '../account/AccountContext'
 import { StatusChangeHandler, doTx } from '../helpers/extrinsics'
 import { useKusama } from '../kusama/KusamaContext'
 import { LoadingSpinner } from '../pages/explore/components/LoadingSpinner'
+import { toastByStatus } from '../pages/explore/helpers'
 
 const StyledP = styled.p`
   color: ${(props) => props.theme.colors.lightGrey};
@@ -19,11 +20,6 @@ const StyledP = styled.p`
 
 interface LevelsType {
   [key: string]: ReactElement
-}
-
-type ExtrinsicResult = {
-  status: 'loading' | 'success' | 'error'
-  message: string
 }
 
 const HumanNextStep = (
@@ -84,7 +80,7 @@ const ClaimMembershipStep = ({
   handleUpdate
 }: {
   api: ApiPromise
-  showMessage: (args: ShowMessageArgs) => any
+  showMessage: (args: ExtrinsicResult) => any
   handleUpdate: () => void
 }) => (
   <>
@@ -119,12 +115,6 @@ const LEVELS: LevelsType = {
   bidder: BidderNextStep,
   candidate: CandidateNextStep,
   cyborg: CyborgNextStep
-}
-
-const toastByStatus = {
-  success: toast.success,
-  loading: toast.loading,
-  error: toast.error
 }
 
 const NextStep = () => {
@@ -176,15 +166,10 @@ const NextStep = () => {
 
 type ClaimMembershipButtonProps = {
   api: ApiPromise
-  showMessage: (args: ShowMessageArgs) => any
+  showMessage: (args: ExtrinsicResult) => any
   handleUpdate: () => void
   successText: string
   waitingText: string
-}
-
-interface ShowMessageArgs {
-  status: 'loading' | 'success' | 'error'
-  message: string
 }
 
 function ClaimMembershipButton({
@@ -198,7 +183,7 @@ function ClaimMembershipButton({
   const { activeAccount } = useAccount()
 
   const onStatusChange: StatusChangeHandler = ({ loading, message, status }) => {
-    setLoading(loading)
+    loading && setLoading(loading)
     showMessage({ status, message })
     if (!loading && status === 'success') handleUpdate()
   }

--- a/src/components/NextStep.tsx
+++ b/src/components/NextStep.tsx
@@ -3,7 +3,6 @@ import { ApiPromise } from '@polkadot/api'
 import { u32 } from '@polkadot/types'
 import { ReactElement, useEffect, useState } from 'react'
 import { Button } from 'react-bootstrap'
-import toast, { Toaster } from 'react-hot-toast'
 import { useLocation } from 'react-router-dom'
 import styled from 'styled-components'
 import { LinkWithQuery } from './LinkWithQuery'
@@ -143,7 +142,6 @@ const NextStep = () => {
   const isClaimPeriod = claim || !isVotingPeriod(votingPeriod, claimPeriod, currentBlock)
 
   const showMessage = (nextResult: ExtrinsicResult) => {
-    toast.dismiss()
     toastByStatus[nextResult.status](nextResult.message, { id: nextResult.message })
   }
 
@@ -153,7 +151,6 @@ const NextStep = () => {
 
   return (
     <>
-      <Toaster />
       <StyledP>{level !== 'cyborg' && 'Next Step'}</StyledP>
       {level === 'candidate' && isClaimPeriod ? (
         <ClaimMembershipStep api={api!} showMessage={showMessage} handleUpdate={handleUpdate} />

--- a/src/components/Toaster.tsx
+++ b/src/components/Toaster.tsx
@@ -32,7 +32,7 @@ const Toaster = () => (
     }}
   >
     {(t) => (
-      <ToastBar toast={t}>
+      <ToastBar style={{ width: '80vw', minHeight: '7vh' }} toast={t}>
         {({ icon, message }) => (
           <>
             {icon}

--- a/src/components/Toaster.tsx
+++ b/src/components/Toaster.tsx
@@ -8,21 +8,20 @@ const Toaster = () => (
     reverseOrder={true}
     toastOptions={{
       success: {
-        duration: 100000,
+        duration: 15000,
         style: {
           background: '#363636',
           color: '#fff'
         }
       },
       error: {
-        duration: 100000,
+        duration: 15000,
         style: {
           background: '#363636',
           color: '#fff'
         }
       },
       loading: {
-        duration: 100000,
         icon: <Spinner size="sm" animation="border" variant="primary" />,
         style: {
           background: '#363636',

--- a/src/components/Toaster.tsx
+++ b/src/components/Toaster.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { Spinner } from 'react-bootstrap'
+import toast, { Toaster as TToaster } from 'react-hot-toast'
+
+const Toaster = () => {
+  return <TToaster
+    position="top-right"
+    reverseOrder={true}
+    toastOptions={{
+      success: {
+        style: {
+          background: '#363636',
+          color: '#fff',
+        },
+      },
+      error: {
+        style: {
+          background: '#363636',
+          color: '#fff',
+        },
+      },
+      loading: {
+        icon: <Spinner size="sm" animation="border" variant="primary" />,
+        style: {
+          background: '#363636',
+          color: '#fff',
+        },
+      }
+    }}
+  />
+}
+
+export { Toaster }

--- a/src/components/Toaster.tsx
+++ b/src/components/Toaster.tsx
@@ -1,33 +1,48 @@
-import React from 'react'
 import { Spinner } from 'react-bootstrap'
-import toast, { Toaster as TToaster } from 'react-hot-toast'
+import toast, { Toaster as TToaster, ToastBar } from 'react-hot-toast'
+import { FaXmark } from 'react-icons/fa6'
 
-const Toaster = () => {
-  return <TToaster
+const Toaster = () => (
+  <TToaster
     position="top-right"
     reverseOrder={true}
     toastOptions={{
       success: {
+        duration: 100000,
         style: {
           background: '#363636',
-          color: '#fff',
-        },
+          color: '#fff'
+        }
       },
       error: {
+        duration: 100000,
         style: {
           background: '#363636',
-          color: '#fff',
-        },
+          color: '#fff'
+        }
       },
       loading: {
+        duration: 100000,
         icon: <Spinner size="sm" animation="border" variant="primary" />,
         style: {
           background: '#363636',
-          color: '#fff',
-        },
+          color: '#fff'
+        }
       }
     }}
-  />
-}
+  >
+    {(t) => (
+      <ToastBar toast={t}>
+        {({ icon, message }) => (
+          <>
+            {icon}
+            {message}
+            {<FaXmark onClick={() => toast.dismiss(t.id)}></FaXmark>}
+          </>
+        )}
+      </ToastBar>
+    )}
+  </TToaster>
+)
 
 export { Toaster }

--- a/src/helpers/extrinsics.ts
+++ b/src/helpers/extrinsics.ts
@@ -7,7 +7,7 @@ export type StatusChangeHandler = (info: StatusChangeInfo) => any
 export interface StatusChangeInfo {
   loading: boolean
   message: string
-  success: boolean
+  status: 'loading' | 'success' | 'error'
 }
 
 export const doTx = async (
@@ -18,14 +18,14 @@ export const doTx = async (
   activeAccount: accountType,
   onStatusChange: StatusChangeHandler
 ) => {
-  onStatusChange({ loading: true, message: 'Awaiting signature...', success: true })
+  onStatusChange({ loading: true, message: 'Awaiting signature...', status: 'loading' })
 
   let injector = null
   try {
     injector = await web3FromAddress(activeAccount.address)
   } catch (e) {
     console.error(e)
-    onStatusChange({ loading: false, message: 'Error connecting to wallet', success: false })
+    onStatusChange({ loading: false, message: 'Error connecting to wallet', status: 'error' })
     return
   }
 
@@ -42,7 +42,7 @@ export const doTx = async (
         const decoded = api!.registry.findMetaError(error.asModule)
         const { docs, method, section } = decoded
 
-        onStatusChange({ loading: false, message: `${section}.${method}: ${docs.join(' ')}`, success: false })
+        onStatusChange({ loading: false, message: `${section}.${method}: ${docs.join(' ')}`, status: 'error' })
         hasError = true
       }
     })
@@ -50,12 +50,12 @@ export const doTx = async (
     if (hasError) return
 
     if (status.isInBlock) {
-      onStatusChange({ loading: false, message: finalizedText, success: true })
+      onStatusChange({ loading: false, message: finalizedText, status: 'success' })
       done = true
     } else if (!done) {
-      onStatusChange({ loading: true, message: waitingText, success: true })
+      onStatusChange({ loading: true, message: waitingText, status: 'success' })
     }
   }).catch((err: Error) => {
-    onStatusChange({ loading: false, message: err.message, success: false })
+    onStatusChange({ loading: false, message: err.message, status: 'error' })
   })
 }

--- a/src/helpers/extrinsics.ts
+++ b/src/helpers/extrinsics.ts
@@ -29,6 +29,10 @@ export const doTx = async (
   type signAndSendProp = { status: any; events: [] }
 
   tx.signAndSend(activeAccount.address, { signer: injector.signer }, ({ status, events }: signAndSendProp) => {
+    if (status.isInBlock) {
+      onStatusChange({ loading: false, message: 'Transaction submitted.', status: 'success' })
+    }
+
     events.map((event) => {
       const error = event?.['event']?.['data']?.[0] as any
 
@@ -43,10 +47,12 @@ export const doTx = async (
 
     if (hasError) return
 
-    if (status.isInBlock) {
+    if (status.isFinalized) {
       onStatusChange({ loading: false, message: finalizedText, status: 'success' })
       done = true
-    } else if (!done) {
+    }
+
+    if (!done) {
       onStatusChange({ loading: true, message: waitingText, status: 'success' })
     }
   }).catch((err: Error) => {

--- a/src/helpers/extrinsics.ts
+++ b/src/helpers/extrinsics.ts
@@ -2,13 +2,7 @@ import { ApiPromise } from '@polkadot/api'
 import { SubmittableExtrinsic } from '@polkadot/api/types'
 import { web3FromAddress } from '@polkadot/extension-dapp'
 
-export type StatusChangeHandler = (info: StatusChangeInfo) => any
-
-export interface StatusChangeInfo {
-  loading: boolean
-  message: string
-  status: 'loading' | 'success' | 'error'
-}
+export type StatusChangeHandler = (info: ExtrinsicResult) => any
 
 export const doTx = async (
   api: ApiPromise,

--- a/src/helpers/extrinsics.ts
+++ b/src/helpers/extrinsics.ts
@@ -53,7 +53,7 @@ export const doTx = async (
     }
 
     if (!done) {
-      onStatusChange({ loading: true, message: waitingText, status: 'success' })
+      onStatusChange({ loading: true, message: waitingText, status: 'loading' })
     }
   }).catch((err: Error) => {
     onStatusChange({ loading: false, message: err.message, status: 'error' })

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -10,6 +10,7 @@ import { LandingPage } from './LandingPage'
 import { WelcomePage } from './WelcomePage'
 import { AccountContextProvider } from '../account/AccountContext'
 import { Navbar } from '../components/Navbar'
+import { Toaster } from '../components/Toaster'
 import { KusamaContextProvider } from '../kusama'
 import { GlobalStyle } from '../styles/globalStyle'
 import { Theme } from '../styles/Theme'
@@ -24,6 +25,7 @@ const AppNavigation = () => {
 
   return (
     <>
+      <Toaster />
       <Navbar showAccount showExploreButton showBrandIcon showSocialIcons />
       <Outlet />
     </>

--- a/src/pages/explore/BiddersPage/BidVouch.tsx
+++ b/src/pages/explore/BiddersPage/BidVouch.tsx
@@ -9,7 +9,7 @@ import { FormatBalance } from '../../../components/FormatBalance'
 import { CurrentRound } from '../../../components/rotation-bar/CurrentRound'
 
 type BidVouchProps = { api: ApiPromise; handleResult: any; activeAccount: accountType }
-type OnStatusChangeProps = { loading: boolean; message: string; success: boolean }
+type OnStatusChangeProps = { loading: boolean; message: string; status: string }
 
 const ksmMultiplier = new BN(1e12)
 
@@ -21,9 +21,9 @@ const BidVouch = ({ api, handleResult, activeAccount }: BidVouchProps) => {
   const [vouchAddress, setVouchAddress] = useState<string>()
   const [loading, setLoading] = useState(false)
 
-  const onStatusChange = ({ loading, message, success }: OnStatusChangeProps) => {
+  const onStatusChange = ({ loading, message, status }: OnStatusChangeProps) => {
     setLoading(loading)
-    handleResult({ message, success })
+    handleResult({ message, status })
   }
 
   useEffect(() => {

--- a/src/pages/explore/BiddersPage/BiddersList.tsx
+++ b/src/pages/explore/BiddersPage/BiddersList.tsx
@@ -18,7 +18,7 @@ type Props = {
   handleResult: any
 }
 
-type OnStatusChangeProps = { loading: boolean; message: string; success: boolean }
+type OnStatusChangeProps = { loading: boolean; message: string; status: string }
 
 // TODO: move this to a `components` directory to follow the convention of other pages
 const BiddersList = ({ api, bids, activeAccount, handleResult }: Props): JSX.Element => {
@@ -27,9 +27,9 @@ const BiddersList = ({ api, bids, activeAccount, handleResult }: Props): JSX.Ele
   const isBidder = (bid: PalletSocietyBid) => activeAccount?.address === bid.who.toString()
   const isVoucher = (bid: PalletSocietyBid) => activeAccount?.address === bid.kind.asVouch?.[0].toString()
 
-  const onStatusChange = ({ loading, message, success }: OnStatusChangeProps) => {
+  const onStatusChange = ({ loading, message, status }: OnStatusChangeProps) => {
     setLoading(loading)
-    handleResult({ message, success })
+    handleResult({ message, status })
   }
 
   const handleUnbid = () => {

--- a/src/pages/explore/BiddersPage/helper.ts
+++ b/src/pages/explore/BiddersPage/helper.ts
@@ -3,6 +3,8 @@ import { SubmittableExtrinsic } from '@polkadot/api/types'
 import BN from 'bn.js'
 import { doTx } from '../../../helpers/extrinsics'
 
+const waitingText = 'Request sent. Waiting for response...'
+
 export const unbid = async (
   api: ApiPromise,
   tx: SubmittableExtrinsic<'promise', any>,
@@ -10,7 +12,6 @@ export const unbid = async (
   onStatusChange: any
 ) => {
   const finalizedText = 'Bid removed successfully. You became Human again.'
-  const waitingText = 'Unbid request sent. Waiting for response...'
 
   await doTx(api, tx, finalizedText, waitingText, activeAccount, onStatusChange)
 }
@@ -22,7 +23,6 @@ export const unvouch = async (
   onStatusChange: any
 ) => {
   const finalizedText = 'Vouch removed successfully.'
-  const waitingText = 'Unvouch request sent. Waiting for response...'
 
   await doTx(api, tx, finalizedText, waitingText, activeAccount, onStatusChange)
 }
@@ -34,7 +34,6 @@ export const bid = async (
   onStatusChange: any
 ) => {
   const finalizedText = 'Bid submitted successfully. You are now a Bidder!'
-  const waitingText = 'Bid request sent. Waiting for response...'
 
   await doTx(api, tx, finalizedText, waitingText, activeAccount, onStatusChange)
 }
@@ -46,7 +45,6 @@ export const vouch = async (
   onStatusChange: any
 ) => {
   const finalizedText = 'Vouch submitted successfully.'
-  const waitingText = 'Vouch request sent. Waiting for response...'
 
   await doTx(api, tx, finalizedText, waitingText, activeAccount, onStatusChange)
 }

--- a/src/pages/explore/BiddersPage/index.tsx
+++ b/src/pages/explore/BiddersPage/index.tsx
@@ -3,13 +3,11 @@ import type { Vec } from '@polkadot/types'
 import type { PalletSocietyBid } from '@polkadot/types/lookup'
 import { useEffect, useState, useCallback } from 'react'
 import { Row, Col } from 'react-bootstrap'
-import toast from 'react-hot-toast'
 import { BiddersList } from './BiddersList'
 import { BidVouch } from './BidVouch'
 import { useAccount } from '../../../account/AccountContext'
 import { LoadingSpinner } from '../components/LoadingSpinner'
 import { toastByStatus } from '../helpers'
-import { Toaster } from '../../../components/Toaster';
 
 type BiddersPageProps = {
   api: ApiPromise | null
@@ -28,7 +26,6 @@ const BiddersPage = ({ api }: BiddersPageProps): JSX.Element => {
   }, [society])
 
   const handleResult = useCallback((nextResult: ExtrinsicResult) => {
-    toast.dismiss()
     toastByStatus[nextResult.status](nextResult.message, { id: nextResult.message })
   }, [])
 
@@ -36,7 +33,6 @@ const BiddersPage = ({ api }: BiddersPageProps): JSX.Element => {
 
   return (
     <>
-      <Toaster />
       <Row>
         <Col>
           <BidVouch api={api!} activeAccount={activeAccount} handleResult={handleResult} />

--- a/src/pages/explore/BiddersPage/index.tsx
+++ b/src/pages/explore/BiddersPage/index.tsx
@@ -3,26 +3,30 @@ import type { Vec } from '@polkadot/types'
 import type { PalletSocietyBid } from '@polkadot/types/lookup'
 import { useEffect, useState, useCallback } from 'react'
 import { Row, Col } from 'react-bootstrap'
+import toast, { Toaster } from 'react-hot-toast'
 import { BiddersList } from './BiddersList'
 import { BidVouch } from './BidVouch'
 import { useAccount } from '../../../account/AccountContext'
 import { LoadingSpinner } from '../components/LoadingSpinner'
-import { StyledAlert } from '../components/StyledAlert'
 
 interface BidResult {
   message: string
-  success: boolean
+  status: 'success' | 'loading' | 'error'
 }
 
 type BiddersPageProps = {
   api: ApiPromise | null
 }
 
+const toastByStatus = {
+  'success': toast.success,
+  'loading': toast.loading,
+  'error': toast.error
+}
+
 const BiddersPage = ({ api }: BiddersPageProps): JSX.Element => {
   const { activeAccount } = useAccount()
   const [bids, setBids] = useState<Vec<PalletSocietyBid> | null>(null)
-  const [result, setResult] = useState<BidResult>()
-  const [showAlert, setShowAlert] = useState(true)
 
   const society = api?.query?.society
 
@@ -32,20 +36,16 @@ const BiddersPage = ({ api }: BiddersPageProps): JSX.Element => {
     })
   }, [society])
 
-  const handleResult = useCallback((result: BidResult) => {
-    setResult(result)
-    setShowAlert(true)
+  const handleResult = useCallback((nextResult: BidResult) => {
+    toast.dismiss()
+    toastByStatus[nextResult.status](nextResult.message, { id: nextResult.message })
   }, [])
 
   if (bids === null) return <LoadingSpinner />
 
   return (
     <>
-      {result && showAlert && (
-        <StyledAlert success={result.success} onClose={() => setShowAlert(false)} dismissible>
-          {result.message}
-        </StyledAlert>
-      )}
+      <Toaster position="top-right" reverseOrder={true} />
       <Row>
         <Col>
           <BidVouch api={api!} activeAccount={activeAccount} handleResult={handleResult} />

--- a/src/pages/explore/BiddersPage/index.tsx
+++ b/src/pages/explore/BiddersPage/index.tsx
@@ -8,20 +8,10 @@ import { BiddersList } from './BiddersList'
 import { BidVouch } from './BidVouch'
 import { useAccount } from '../../../account/AccountContext'
 import { LoadingSpinner } from '../components/LoadingSpinner'
-
-interface BidResult {
-  message: string
-  status: 'success' | 'loading' | 'error'
-}
+import { toastByStatus } from '../helpers'
 
 type BiddersPageProps = {
   api: ApiPromise | null
-}
-
-const toastByStatus = {
-  'success': toast.success,
-  'loading': toast.loading,
-  'error': toast.error
 }
 
 const BiddersPage = ({ api }: BiddersPageProps): JSX.Element => {
@@ -36,7 +26,7 @@ const BiddersPage = ({ api }: BiddersPageProps): JSX.Element => {
     })
   }, [society])
 
-  const handleResult = useCallback((nextResult: BidResult) => {
+  const handleResult = useCallback((nextResult: ExtrinsicResult) => {
     toast.dismiss()
     toastByStatus[nextResult.status](nextResult.message, { id: nextResult.message })
   }, [])

--- a/src/pages/explore/BiddersPage/index.tsx
+++ b/src/pages/explore/BiddersPage/index.tsx
@@ -3,12 +3,13 @@ import type { Vec } from '@polkadot/types'
 import type { PalletSocietyBid } from '@polkadot/types/lookup'
 import { useEffect, useState, useCallback } from 'react'
 import { Row, Col } from 'react-bootstrap'
-import toast, { Toaster } from 'react-hot-toast'
+import toast from 'react-hot-toast'
 import { BiddersList } from './BiddersList'
 import { BidVouch } from './BidVouch'
 import { useAccount } from '../../../account/AccountContext'
 import { LoadingSpinner } from '../components/LoadingSpinner'
 import { toastByStatus } from '../helpers'
+import { Toaster } from '../../../components/Toaster';
 
 type BiddersPageProps = {
   api: ApiPromise | null
@@ -35,7 +36,7 @@ const BiddersPage = ({ api }: BiddersPageProps): JSX.Element => {
 
   return (
     <>
-      <Toaster position="top-right" reverseOrder={true} />
+      <Toaster />
       <Row>
         <Col>
           <BidVouch api={api!} activeAccount={activeAccount} handleResult={handleResult} />

--- a/src/pages/explore/CandidatesPage/components/CandidatesList.tsx
+++ b/src/pages/explore/CandidatesPage/components/CandidatesList.tsx
@@ -16,6 +16,7 @@ import { truncate } from '../../../../helpers/truncate'
 import ApproveIcon from '../../../../static/approve-icon.svg'
 import CheckAllIcon from '../../../../static/check-all-icon.svg'
 import RejectIcon from '../../../../static/reject-icon.svg'
+import { toastByStatus } from '../../helpers'
 
 const StyledCol = styled(Col)`
   &:hover {
@@ -30,23 +31,12 @@ type CandidatesListProps = {
   handleUpdate: () => void
 }
 
-type VoteResult = {
-  status: 'loading' | 'success' | 'error'
-  message: string
-}
-
 const AlreadyVotedIcon = () => (
   <>
     <img src={CheckAllIcon} className="me-2" />
     <label style={{ color: '#6c757d' }}>Voted</label>
   </>
 )
-
-const toastByStatus = {
-  'success': toast.success,
-  'loading': toast.loading,
-  'error': toast.error
-}
 
 const CandidatesList = ({ api, activeAccount, candidates, handleUpdate }: CandidatesListProps): JSX.Element => {
   const [votes, setVotes] = useState<SocietyCandidate[]>([])
@@ -55,7 +45,7 @@ const CandidatesList = ({ api, activeAccount, candidates, handleUpdate }: Candid
   const [selectedCandidate, setSelectedCandidate] = useState<AccountId | null>(null)
   const [showCandidateDetailsOffcanvas, setShowCandidateDetailsOffcanvas] = useState(false)
 
-  const showMessage = (nextResult: VoteResult) => {
+  const showMessage = (nextResult: ExtrinsicResult) => {
     toast.dismiss()
     toastByStatus[nextResult.status](nextResult.message, { id: nextResult.message })
   }

--- a/src/pages/explore/CandidatesPage/components/CandidatesList.tsx
+++ b/src/pages/explore/CandidatesPage/components/CandidatesList.tsx
@@ -4,7 +4,6 @@ import type { Option } from '@polkadot/types'
 import type { SocietyVote, AccountId } from '@polkadot/types/interfaces'
 import { useEffect, useRef, useState } from 'react'
 import { Badge, Col } from 'react-bootstrap'
-import toast from 'react-hot-toast'
 import styled from 'styled-components'
 import { CandidateDetailsOffcanvas } from './CandidateDetailsOffcanvas'
 import { VoteButton } from './VoteButton'
@@ -17,7 +16,6 @@ import ApproveIcon from '../../../../static/approve-icon.svg'
 import CheckAllIcon from '../../../../static/check-all-icon.svg'
 import RejectIcon from '../../../../static/reject-icon.svg'
 import { toastByStatus } from '../../helpers'
-import { Toaster } from '../../../../components/Toaster';
 
 const StyledCol = styled(Col)`
   &:hover {
@@ -47,7 +45,6 @@ const CandidatesList = ({ api, activeAccount, candidates, handleUpdate }: Candid
   const [showCandidateDetailsOffcanvas, setShowCandidateDetailsOffcanvas] = useState(false)
 
   const showMessage = (nextResult: ExtrinsicResult) => {
-    toast.dismiss()
     toastByStatus[nextResult.status](nextResult.message, { id: nextResult.message })
   }
 
@@ -97,7 +94,6 @@ const CandidatesList = ({ api, activeAccount, candidates, handleUpdate }: Candid
           onClose={() => setShowCandidateDetailsOffcanvas(false)}
         />
       )}
-      <Toaster />
 
       <DataHeaderRow>
         <Col xs={1} className="text-center">

--- a/src/pages/explore/CandidatesPage/components/CandidatesList.tsx
+++ b/src/pages/explore/CandidatesPage/components/CandidatesList.tsx
@@ -4,6 +4,7 @@ import type { Option } from '@polkadot/types'
 import type { SocietyVote, AccountId } from '@polkadot/types/interfaces'
 import { useEffect, useRef, useState } from 'react'
 import { Badge, Col } from 'react-bootstrap'
+import toast, { Toaster } from 'react-hot-toast'
 import styled from 'styled-components'
 import { CandidateDetailsOffcanvas } from './CandidateDetailsOffcanvas'
 import { VoteButton } from './VoteButton'
@@ -15,7 +16,6 @@ import { truncate } from '../../../../helpers/truncate'
 import ApproveIcon from '../../../../static/approve-icon.svg'
 import CheckAllIcon from '../../../../static/check-all-icon.svg'
 import RejectIcon from '../../../../static/reject-icon.svg'
-import { StyledAlert } from '../../components/StyledAlert'
 
 const StyledCol = styled(Col)`
   &:hover {
@@ -31,7 +31,7 @@ type CandidatesListProps = {
 }
 
 type VoteResult = {
-  success: boolean
+  status: 'loading' | 'success' | 'error'
   message: string
 }
 
@@ -42,17 +42,22 @@ const AlreadyVotedIcon = () => (
   </>
 )
 
+const toastByStatus = {
+  'success': toast.success,
+  'loading': toast.loading,
+  'error': toast.error
+}
+
 const CandidatesList = ({ api, activeAccount, candidates, handleUpdate }: CandidatesListProps): JSX.Element => {
-  const [showAlert, setShowAlert] = useState(false)
   const [votes, setVotes] = useState<SocietyCandidate[]>([])
-  const [voteResult, setVoteResult] = useState<VoteResult>({ success: false, message: '' })
   const society = api?.query?.society
 
   const [selectedCandidate, setSelectedCandidate] = useState<AccountId | null>(null)
   const [showCandidateDetailsOffcanvas, setShowCandidateDetailsOffcanvas] = useState(false)
-  const showMessage = (result: VoteResult) => {
-    setVoteResult(result)
-    setShowAlert(true)
+
+  const showMessage = (nextResult: VoteResult) => {
+    toast.dismiss()
+    toastByStatus[nextResult.status](nextResult.message, { id: nextResult.message })
   }
 
   const usePrevious = (value: any) => {
@@ -101,10 +106,7 @@ const CandidatesList = ({ api, activeAccount, candidates, handleUpdate }: Candid
           onClose={() => setShowCandidateDetailsOffcanvas(false)}
         />
       )}
-
-      <StyledAlert success={voteResult.success} onClose={() => setShowAlert(false)} show={showAlert} dismissible>
-        {voteResult.message}
-      </StyledAlert>
+      <Toaster position="top-right" reverseOrder={true} />
 
       <DataHeaderRow>
         <Col xs={1} className="text-center">

--- a/src/pages/explore/CandidatesPage/components/CandidatesList.tsx
+++ b/src/pages/explore/CandidatesPage/components/CandidatesList.tsx
@@ -4,7 +4,7 @@ import type { Option } from '@polkadot/types'
 import type { SocietyVote, AccountId } from '@polkadot/types/interfaces'
 import { useEffect, useRef, useState } from 'react'
 import { Badge, Col } from 'react-bootstrap'
-import toast, { Toaster } from 'react-hot-toast'
+import toast from 'react-hot-toast'
 import styled from 'styled-components'
 import { CandidateDetailsOffcanvas } from './CandidateDetailsOffcanvas'
 import { VoteButton } from './VoteButton'
@@ -17,6 +17,7 @@ import ApproveIcon from '../../../../static/approve-icon.svg'
 import CheckAllIcon from '../../../../static/check-all-icon.svg'
 import RejectIcon from '../../../../static/reject-icon.svg'
 import { toastByStatus } from '../../helpers'
+import { Toaster } from '../../../../components/Toaster';
 
 const StyledCol = styled(Col)`
   &:hover {
@@ -96,7 +97,7 @@ const CandidatesList = ({ api, activeAccount, candidates, handleUpdate }: Candid
           onClose={() => setShowCandidateDetailsOffcanvas(false)}
         />
       )}
-      <Toaster position="top-right" reverseOrder={true} />
+      <Toaster />
 
       <DataHeaderRow>
         <Col xs={1} className="text-center">

--- a/src/pages/explore/CandidatesPage/components/VoteButton.tsx
+++ b/src/pages/explore/CandidatesPage/components/VoteButton.tsx
@@ -8,17 +8,12 @@ import { LoadingSpinner } from '../../components/LoadingSpinner'
 type VoteButtonProps = {
   api: ApiPromise
   vote: Vote
-  showMessage: (args: ShowMessageArgs) => any
+  showMessage: (args: ExtrinsicResult) => any
   icon: string
   handleUpdate: () => void
   successText: string
   waitingText: string
   children: JSX.Element
-}
-
-export interface ShowMessageArgs {
-  status: 'loading' | 'success' | 'error'
-  message: string
 }
 
 export interface Vote {
@@ -41,7 +36,7 @@ export function VoteButton({
   const [loading, setLoading] = useState(false)
 
   const onStatusChange: StatusChangeHandler = ({ loading, message, status }) => {
-    setLoading(loading)
+    loading && setLoading(loading)
     showMessage({ status, message })
     handleUpdate()
   }

--- a/src/pages/explore/CandidatesPage/components/VoteButton.tsx
+++ b/src/pages/explore/CandidatesPage/components/VoteButton.tsx
@@ -17,7 +17,7 @@ type VoteButtonProps = {
 }
 
 export interface ShowMessageArgs {
-  success: boolean
+  status: 'loading' | 'success' | 'error'
   message: string
 }
 
@@ -40,9 +40,9 @@ export function VoteButton({
 }: VoteButtonProps) {
   const [loading, setLoading] = useState(false)
 
-  const onStatusChange: StatusChangeHandler = ({ loading, message, success }) => {
+  const onStatusChange: StatusChangeHandler = ({ loading, message, status }) => {
     setLoading(loading)
-    showMessage({ success, message })
+    showMessage({ status, message })
     handleUpdate()
   }
 

--- a/src/pages/explore/MembersPage/components/MembersList.tsx
+++ b/src/pages/explore/MembersPage/components/MembersList.tsx
@@ -2,7 +2,7 @@ import type { ApiPromise } from '@polkadot/api'
 import Identicon from '@polkadot/react-identicon'
 import { useEffect, useRef, useState } from 'react'
 import { Badge, Col } from 'react-bootstrap'
-import toast, { Toaster } from 'react-hot-toast'
+import toast from 'react-hot-toast'
 import styled from 'styled-components'
 import { useAccount } from '../../../../account/AccountContext'
 import { AccountIdentity } from '../../../../components/AccountIdentity'
@@ -13,6 +13,7 @@ import CheckAllIcon from '../../../../static/check-all-icon.svg'
 import RejectIcon from '../../../../static/reject-icon.svg'
 import { VoteButton } from '../../CandidatesPage/components/VoteButton'
 import { toastByStatus } from '../../helpers'
+import { Toaster } from '../../../../components/Toaster';
 
 const StyledDataRow = styled(DataRow)`
   background-color: ${(props) => (props.$isDefender ? '#73003d' : '')};
@@ -72,7 +73,7 @@ const MembersList = ({ api, members, activeAccount, onClickMember, handleUpdate 
 
   return (
     <>
-      <Toaster position="top-right" reverseOrder={true} />
+      <Toaster />
       <DataHeaderRow>
         <Col xs={1} className="text-center">
           #

--- a/src/pages/explore/MembersPage/components/MembersList.tsx
+++ b/src/pages/explore/MembersPage/components/MembersList.tsx
@@ -12,6 +12,7 @@ import ApproveIcon from '../../../../static/approve-icon.svg'
 import CheckAllIcon from '../../../../static/check-all-icon.svg'
 import RejectIcon from '../../../../static/reject-icon.svg'
 import { VoteButton } from '../../CandidatesPage/components/VoteButton'
+import { toastByStatus } from '../../helpers'
 
 const StyledDataRow = styled(DataRow)`
   background-color: ${(props) => (props.$isDefender ? '#73003d' : '')};
@@ -27,17 +28,6 @@ type MembersListProps = {
   activeAccount: accountType
   onClickMember: (member: SocietyMember) => any
   handleUpdate: () => void
-}
-
-type VoteResult = {
-  status: 'loading' | 'success' | 'error'
-  message: string
-}
-
-const toastByStatus = {
-  'success': toast.success,
-  'loading': toast.loading,
-  'error': toast.error
 }
 
 const AlreadyVotedIcon = () => (
@@ -57,7 +47,7 @@ const MembersList = ({ api, members, activeAccount, onClickMember, handleUpdate 
 
   const [activeAccountIsDefenderVoter, setActiveAccountIsDefenderVoter] = useState(false)
 
-  const showMessage = (nextResult: VoteResult) => {
+  const showMessage = (nextResult: ExtrinsicResult) => {
     toast.dismiss()
     toastByStatus[nextResult.status](nextResult.message, { id: nextResult.message })
   }

--- a/src/pages/explore/MembersPage/components/MembersList.tsx
+++ b/src/pages/explore/MembersPage/components/MembersList.tsx
@@ -2,6 +2,7 @@ import type { ApiPromise } from '@polkadot/api'
 import Identicon from '@polkadot/react-identicon'
 import { useEffect, useRef, useState } from 'react'
 import { Badge, Col } from 'react-bootstrap'
+import toast, { Toaster } from 'react-hot-toast'
 import styled from 'styled-components'
 import { useAccount } from '../../../../account/AccountContext'
 import { AccountIdentity } from '../../../../components/AccountIdentity'
@@ -11,7 +12,6 @@ import ApproveIcon from '../../../../static/approve-icon.svg'
 import CheckAllIcon from '../../../../static/check-all-icon.svg'
 import RejectIcon from '../../../../static/reject-icon.svg'
 import { VoteButton } from '../../CandidatesPage/components/VoteButton'
-import { StyledAlert } from '../../components/StyledAlert'
 
 const StyledDataRow = styled(DataRow)`
   background-color: ${(props) => (props.$isDefender ? '#73003d' : '')};
@@ -30,8 +30,14 @@ type MembersListProps = {
 }
 
 type VoteResult = {
-  success: boolean
+  status: 'loading' | 'success' | 'error'
   message: string
+}
+
+const toastByStatus = {
+  'success': toast.success,
+  'loading': toast.loading,
+  'error': toast.error
 }
 
 const AlreadyVotedIcon = () => (
@@ -49,13 +55,11 @@ const MembersList = ({ api, members, activeAccount, onClickMember, handleUpdate 
   const { level } = useAccount()
   const activeAccountIsMember = level === 'cyborg'
 
-  const [showAlert, setShowAlert] = useState(false)
   const [activeAccountIsDefenderVoter, setActiveAccountIsDefenderVoter] = useState(false)
-  const [voteResult, setVoteResult] = useState<VoteResult>({ success: false, message: '' })
 
-  const showMessage = (result: VoteResult) => {
-    setVoteResult(result)
-    setShowAlert(true)
+  const showMessage = (nextResult: VoteResult) => {
+    toast.dismiss()
+    toastByStatus[nextResult.status](nextResult.message, { id: nextResult.message })
   }
 
   const usePrevious = (value: any) => {
@@ -78,10 +82,7 @@ const MembersList = ({ api, members, activeAccount, onClickMember, handleUpdate 
 
   return (
     <>
-      <StyledAlert success={voteResult.success} onClose={() => setShowAlert(false)} show={showAlert} dismissible>
-        {voteResult.message}
-      </StyledAlert>
-
+      <Toaster position="top-right" reverseOrder={true} />
       <DataHeaderRow>
         <Col xs={1} className="text-center">
           #

--- a/src/pages/explore/MembersPage/components/MembersList.tsx
+++ b/src/pages/explore/MembersPage/components/MembersList.tsx
@@ -2,7 +2,6 @@ import type { ApiPromise } from '@polkadot/api'
 import Identicon from '@polkadot/react-identicon'
 import { useEffect, useRef, useState } from 'react'
 import { Badge, Col } from 'react-bootstrap'
-import toast from 'react-hot-toast'
 import styled from 'styled-components'
 import { useAccount } from '../../../../account/AccountContext'
 import { AccountIdentity } from '../../../../components/AccountIdentity'
@@ -13,7 +12,6 @@ import CheckAllIcon from '../../../../static/check-all-icon.svg'
 import RejectIcon from '../../../../static/reject-icon.svg'
 import { VoteButton } from '../../CandidatesPage/components/VoteButton'
 import { toastByStatus } from '../../helpers'
-import { Toaster } from '../../../../components/Toaster';
 
 const StyledDataRow = styled(DataRow)`
   background-color: ${(props) => (props.$isDefender ? '#73003d' : '')};
@@ -49,7 +47,6 @@ const MembersList = ({ api, members, activeAccount, onClickMember, handleUpdate 
   const [activeAccountIsDefenderVoter, setActiveAccountIsDefenderVoter] = useState(false)
 
   const showMessage = (nextResult: ExtrinsicResult) => {
-    toast.dismiss()
     toastByStatus[nextResult.status](nextResult.message, { id: nextResult.message })
   }
 
@@ -73,7 +70,6 @@ const MembersList = ({ api, members, activeAccount, onClickMember, handleUpdate 
 
   return (
     <>
-      <Toaster />
       <DataHeaderRow>
         <Col xs={1} className="text-center">
           #

--- a/src/pages/explore/components/NavigationBar.tsx
+++ b/src/pages/explore/components/NavigationBar.tsx
@@ -48,6 +48,11 @@ const NavigationBar = ({ totals }: { totals: Totals }) => {
             Proof of Ink
           </Nav.Link>
         </StyledNavItem>
+        <StyledNavItem>
+          <Nav.Link as={LinkWithQuery} to="/journey">
+            Journey
+          </Nav.Link>
+        </StyledNavItem>
       </StyledNav>
       {showSubNav && (
         <StyledNav defaultActiveKey="/explore/poi/examples" className="py-2 mb-4">

--- a/src/pages/explore/helpers.ts
+++ b/src/pages/explore/helpers.ts
@@ -2,6 +2,7 @@ import type { ApiPromise } from '@polkadot/api'
 import { StorageKey, u32 } from '@polkadot/types'
 import type { AccountId, AccountId32 } from '@polkadot/types/interfaces'
 import { BN } from '@polkadot/util'
+import toast from 'react-hot-toast'
 import { combineLatest, firstValueFrom, map, of } from 'rxjs'
 
 function buildSocietyCandidatesArray(response: any): SocietyCandidate[] {
@@ -12,6 +13,12 @@ function buildSocietyCandidatesArray(response: any): SocietyCandidate[] {
     tally: item[1].unwrap().tally,
     skepticStruck: item[1].unwrap().skepticStruck
   }))
+}
+
+const toastByStatus = {
+  'success': toast.success,
+  'loading': toast.loading,
+  'error': toast.error
 }
 
 const buildSocietyMembersArray = (
@@ -105,4 +112,4 @@ async function deriveMembersInfo(api: ApiPromise): Promise<ExtendedDeriveSociety
   )
 }
 
-export { buildSocietyCandidatesArray, buildSocietyMembersArray, deriveMembersInfo }
+export { toastByStatus, buildSocietyCandidatesArray, buildSocietyMembersArray, deriveMembersInfo }

--- a/src/pages/explore/helpers.tsx
+++ b/src/pages/explore/helpers.tsx
@@ -18,9 +18,13 @@ function buildSocietyCandidatesArray(response: any): SocietyCandidate[] {
 const toastByStatus = {
   success: (message: string, params: object) => {
     toast.dismiss('Awaiting signature...')
+    toast.dismiss('Request sent. Waiting for response...')
     return toast.success(message, params)
   },
-  loading: toast.loading,
+  loading: (message: string, params: object) => {
+    toast.dismiss('Awaiting signature...')
+    return toast.loading(message, params)
+  },
   error: (message: string, params: object) => {
     toast.dismiss('Awaiting signature...')
     return toast.error(message, params)

--- a/src/pages/explore/helpers.tsx
+++ b/src/pages/explore/helpers.tsx
@@ -16,9 +16,15 @@ function buildSocietyCandidatesArray(response: any): SocietyCandidate[] {
 }
 
 const toastByStatus = {
-  'success': toast.success,
-  'loading': toast.loading,
-  'error': toast.error
+  success: (message: string, params: object) => {
+    toast.dismiss('Awaiting signature...')
+    return toast.success(message, params)
+  },
+  loading: toast.loading,
+  error: (message: string, params: object) => {
+    toast.dismiss('Awaiting signature...')
+    return toast.error(message, params)
+  }
 }
 
 const buildSocietyMembersArray = (

--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -46,6 +46,10 @@ const GlobalStyle = createGlobalStyle`
   p {
     color: #c4c4c4;
   }
+
+  div[role="status"] {
+    justify-content: flex-start;
+  }
 `
 
 export { GlobalStyle }

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -89,3 +89,9 @@ namespace NodeJS {
     REACT_APP_PROVIDER_SOCKET: string
   }
 }
+
+interface ExtrinsicResult {
+  message: string
+  status: 'success' | 'loading' | 'error'
+  loading?: boolean
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6957,6 +6957,11 @@ glsl-noise@^0.0.0:
   resolved "https://registry.yarnpkg.com/glsl-noise/-/glsl-noise-0.0.0.tgz#367745f3a33382c0eeec4cb54b7e99cfc1d7670b"
   integrity sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==
 
+goober@^2.1.10:
+  version "2.1.13"
+  resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.13.tgz#e3c06d5578486212a76c9eba860cbc3232ff6d7c"
+  integrity sha512-jFj3BQeleOoy7t93E9rZ2de+ScC4lQICLwiAQmKMg9F6roKGaLSHoCDYKkWlSafg138jejvq/mTdvmnwDQgqoQ==
+
 gopd@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
@@ -11123,6 +11128,13 @@ react-error-overlay@^6.0.11:
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
+
+react-hot-toast@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/react-hot-toast/-/react-hot-toast-2.4.1.tgz#df04295eda8a7b12c4f968e54a61c8d36f4c0994"
+  integrity sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==
+  dependencies:
+    goober "^2.1.10"
 
 react-icons@^4.12.0:
   version "4.12.0"


### PR DESCRIPTION
Hey there!

In this PR, we change the previous transaction messages as alerts to toasts, as present on the following video:

![image](https://github.com/KappaSigmaMu/kappasigmamu.github.io/assets/21130697/ed17e7ba-5434-4287-a9d7-6d60e498100e)


Note: the toasts are still not persistent between page changes.