### PR TITLE
ci: split workflows into lint, smoke e2e, and bidding e2e

### DIFF
--- a/.github/workflows/test-e2e-bidding.yml
+++ b/.github/workflows/test-e2e-bidding.yml
@@ -1,0 +1,46 @@
+name: Bidding E2E
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-e2e-bidding:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Cache yarn dependencies
+        uses: actions/cache@v4
+        with:
+          path: .yarn/cache
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Run bidding E2E tests
+        run: yarn test:e2e:bidding
+
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: cypress-bidding-screenshots
+          path: cypress/screenshots
+          include-hidden-files: true

--- a/.github/workflows/test-e2e-smoke.yml
+++ b/.github/workflows/test-e2e-smoke.yml
@@ -1,0 +1,46 @@
+name: Smoke E2E
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-e2e-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Cache yarn dependencies
+        uses: actions/cache@v4
+        with:
+          path: .yarn/cache
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Run smoke E2E tests
+        run: yarn test:e2e:smoke
+
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: cypress-smoke-screenshots
+          path: cypress/screenshots
+          include-hidden-files: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+name: Lint & Unit Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Cache yarn dependencies
+        uses: actions/cache@v4
+        with:
+          path: .yarn/cache
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Unit tests
+        run: CI=true yarn test --watchAll=false --coverage

--- a/package.json
+++ b/package.json
@@ -144,6 +144,8 @@
     "test": "node scripts/test.js",
     "test:e2e": "cypress run",
     "test:e2e:ci": "start-server-and-test chopsticks http://localhost:8000 'start-server-and-test start http://localhost:3000 \"cypress run --config video=false\"'",
+    "test:e2e:smoke": "start-server-and-test chopsticks http://localhost:8000 'start-server-and-test start http://localhost:3000 \"cypress run --spec cypress/e2e/smoke.cy.ts --config video=false\"'",
+    "test:e2e:bidding": "start-server-and-test chopsticks http://localhost:8000 'start-server-and-test start http://localhost:3000 \"cypress run --spec cypress/e2e/wallet-connection.cy.ts --config video=false\"'",
     "test:e2e:headed": "cypress run --headed",
     "test:e2e:open": "cypress open",
     "test:debug": "cypress open --config watchForFileChanges=true"


### PR DESCRIPTION
## Summary

- Add three parallel CI workflows replacing the missing CI setup
- Lint & unit tests run independently from E2E (no chopsticks needed, faster feedback)
- Smoke E2E and Bidding E2E run as separate isolated jobs in parallel
- Yarn dependency cache added to all three workflows
- `cancel-in-progress` concurrency prevents stale runs from wasting minutes

## Bottlenecks addressed

| Problem | Fix |
|---|---|
| No CI at all | Three isolated workflows |
| No dep caching | `actions/cache` on `.yarn/cache` keyed by `yarn.lock` |
| Lint blocked by chopsticks startup | Lint+unit workflow has zero blockchain infra |
| All specs in one sequential job | Smoke and bidding run in parallel |
| Stale run waste | `cancel-in-progress: true` on all workflows |

## New scripts (package.json)

- `test:e2e:smoke` — runs `smoke.cy.ts` only
- `test:e2e:bidding` — runs `wallet-connection.cy.ts` (add future bidding specs here)