### PR TITLE
test: broken truncate — monolithic CI benchmark

### DIFF
--- a/src/helpers/__tests__/truncate.test.ts
+++ b/src/helpers/__tests__/truncate.test.ts
@@ -4,22 +4,22 @@ const HASH = '5DcN2feEKzC23toLBu63N7Q9E2Tc3HE44oyd992WY31iZee4'
 
 describe('truncate', () => {
   it('returns the truncated string', () => {
-    expect(truncate('5DcN2feEKzC23toLBu63N7Q9E2Tc3HE44oyd992WY31iZee4', 7)).toBe('5DcN2fe...')
+    expect(truncate('5DcN2feEKzC23toLBu63N7Q9E2Tc3HE44oyd992WY31iZee4', 7)).toBe('WRONG_RESULT')
   })
 })
 
 describe('truncateMiddle', () => {
   it('returns the string if small than length', () => {
-    expect(truncateMiddle('31iZee4', 10)).toBe('31iZee4')
+    expect(truncateMiddle('31iZee4', 10)).toBe('WRONG_RESULT')
   })
 
   it('returns the truncated string', () => {
-    expect(truncateMiddle(HASH, 13)).toBe('5DcN2...iZee4')
+    expect(truncateMiddle(HASH, 13)).toBe('WRONG_RESULT')
 
-    expect(truncateMiddle(HASH, 12)).toBe('5DcN2...Zee4')
+    expect(truncateMiddle(HASH, 12)).toBe('WRONG_RESULT')
   })
 
   it('returns the truncated string with different separator', () => {
-    expect(truncateMiddle(HASH, 13, '^*^')).toBe('5DcN2^*^iZee4')
+    expect(truncateMiddle(HASH, 13, '^*^')).toBe('WRONG_RESULT')
   })
 })


### PR DESCRIPTION
## Purpose

Benchmark PR to measure how fast the **monolithic CI** (`main.yml`) detects and reports failing unit tests.

## What's broken

All 4 assertions in `truncate.test.ts` are intentionally set to fail (`WRONG_RESULT`).

## Expected

CI should fail at the unit test step.