### PR TITLE
test(e2e): address review feedback — remove flaky waits and forced clicks

### DIFF
--- a/cypress/e2e/bidding.cy.ts
+++ b/cypress/e2e/bidding.cy.ts
@@ -1,7 +1,7 @@
 import { InjectedAccountWitMnemonic } from '@chainsafe/cypress-polkadot-wallet/dist/types'
 
 const visitBiddersPage = () => {
-  cy.visit('/explore/bidders?rpc=ws://localhost:8000', { timeout: 20000 })
+  cy.visit('/explore/bidders?rpc=ws://localhost:8000')
   cy.getBySel('blockchain-data', { timeout: 20000 }).should('be.visible')
 }
 

--- a/cypress/e2e/smoke.cy.ts
+++ b/cypress/e2e/smoke.cy.ts
@@ -184,8 +184,7 @@ describe('API Connection Smoke Tests', () => {
   it('should initialize API without crashing', () => {
     cy.visit('/explore/members?rpc=ws://localhost:8000')
 
-    cy.wait(5000)
-
+    cy.getBySel('blockchain-data', { timeout: 20000 }).should('be.visible')
     cy.get('body').should('be.visible')
     cy.get('nav').should('exist')
   })

--- a/cypress/e2e/wallet-connection.cy.ts
+++ b/cypress/e2e/wallet-connection.cy.ts
@@ -2,7 +2,7 @@ import { InjectedAccountWitMnemonic } from '@chainsafe/cypress-polkadot-wallet/d
 
 describe('Wallet Connection UI Flow', () => {
   beforeEach(() => {
-    cy.visit('/explore?rpc=ws://localhost:8000', { timeout: 20000 })
+    cy.visit('/explore?rpc=ws://localhost:8000')
     cy.getBySel('blockchain-data', { timeout: 20000 }).should('be.visible')
   })
 
@@ -73,7 +73,7 @@ describe('Connect Wallet with Plugin', () => {
   })
 
   beforeEach(() => {
-    cy.visit('/explore/bidders?rpc=ws://localhost:8000', { timeout: 20000 })
+    cy.visit('/explore/bidders?rpc=ws://localhost:8000')
     cy.initWallet(testAccounts, Cypress.env('app_name'))
     cy.getBySel('blockchain-data', { timeout: 20000 }).should('be.visible')
   })

--- a/cypress/e2e/wallet-plugin-integration.cy.ts
+++ b/cypress/e2e/wallet-plugin-integration.cy.ts
@@ -16,16 +16,16 @@ describe('Wallet Plugin Integration', () => {
 
   describe('Account Injection', () => {
     beforeEach(() => {
-      cy.visit('/explore?rpc=ws://localhost:8000', { timeout: 20000 })
+      cy.visit('/explore?rpc=ws://localhost:8000')
       cy.initWallet(testAccounts, Cypress.env('app_name'))
-      cy.wait(1000)
+      cy.getBySel('blockchain-data', { timeout: 20000 }).should('be.visible')
     })
 
     it('should inject all test accounts into wallet', () => {
-      cy.contains('button', /connect/i).should('be.visible').click({ force: true })
+      cy.contains('button', /connect/i).should('be.visible').click()
       cy.getBySel('wallet-polkadot', { timeout: 15000 }).should('be.visible')
         .parent().should('contain.text', 'Use')
-      cy.getBySel('wallet-polkadot').click({ force: true })
+      cy.getBySel('wallet-polkadot').click()
 
       cy.getBySel('account-switcher', { timeout: 10000 }).should('have.length', 6)
       cy.get('.modal-body').within(() => {
@@ -66,9 +66,9 @@ describe('Wallet Plugin Integration', () => {
 
   describe('Wallet Disconnect', () => {
     beforeEach(() => {
-      cy.visit('/explore?rpc=ws://localhost:8000', { timeout: 20000 })
+      cy.visit('/explore?rpc=ws://localhost:8000')
       cy.initWallet(testAccounts, Cypress.env('app_name'))
-      cy.wait(500)
+      cy.getBySel('blockchain-data', { timeout: 20000 }).should('be.visible')
     })
 
     it('should disconnect wallet and return to initial state', () => {
@@ -97,16 +97,16 @@ describe('Wallet Plugin Integration', () => {
 
   describe('Wallet Persistence', () => {
     beforeEach(() => {
-      cy.visit('/explore?rpc=ws://localhost:8000', { timeout: 20000 })
+      cy.visit('/explore?rpc=ws://localhost:8000')
       cy.initWallet(testAccounts, Cypress.env('app_name'))
-      cy.wait(500)
+      cy.getBySel('blockchain-data', { timeout: 20000 }).should('be.visible')
     })
 
     it('should persist wallet across page navigation', () => {
       cy.connectWallet('Eve')
       cy.getBySel('account-balance').should('be.visible')
 
-      cy.visit('/explore/members?rpc=ws://localhost:8000', { timeout: 20000 })
+      cy.visit('/explore/members?rpc=ws://localhost:8000')
 
       cy.getBySel('account-balance', { timeout: 15000 }).should('be.visible')
     })
@@ -114,9 +114,9 @@ describe('Wallet Plugin Integration', () => {
 
   describe('Transaction Approval', () => {
     beforeEach(() => {
-      cy.visit('/explore?rpc=ws://localhost:8000', { timeout: 20000 })
+      cy.visit('/explore?rpc=ws://localhost:8000')
       cy.initWallet(testAccounts, Cypress.env('app_name'))
-      cy.wait(500)
+      cy.getBySel('blockchain-data', { timeout: 20000 }).should('be.visible')
     })
 
     it('should handle transaction request queue', () => {


### PR DESCRIPTION
## TL;DR

Pay down E2E debt from #227 + #228 (merged with CHANGES_REQUESTED). Remove flakiness vectors Lauro flagged. Test-only, no prod code.

## Description

Addresses @laurogripa review comments:

| PR | Comment | Fix |
|----|---------|-----|
| #227 `wallet-connection.cy.ts:41` | force-clicks → flakiness | dropped all `{ force: true }` |
| #227 `bidding.cy.ts:204` | 1s wait per test excessive | replaced blind `cy.wait` with `blockchain-data` assertion |
| #228 | 20s/30s timeout on simple `visit` excessive | dropped `cy.visit` timeouts; assertions keep own timeout |

Already fixed on main (noted, no action): `e2e.ts:4` exception swallow (`af47c2b3`), `dev_setHead` capture-before-change (`rememberForkPoint`), `waitForBlockchainData` misnomer (command gone).

Files: `bidding`, `smoke`, `wallet-connection`, `wallet-plugin-integration`. Kept retry-poll `cy.wait` in `commands.ts` (bounded interval, not blind delay).
